### PR TITLE
Matching matrix sizes

### DIFF
--- a/PyTorch/main.py
+++ b/PyTorch/main.py
@@ -129,7 +129,7 @@ def test_optim_lbfgs():
     optimizer.step(closure)
 
 def test_triangular_solve():
-    b = torch.randn(2, 3)
+    b = torch.randn(3, 3)
     A = torch.randn(3, 3)
     torch.triangular_solve(b, A)
 


### PR DESCRIPTION
To fix error:
RuntimeError: Incompatible matrix sizes for triangular_solve: each A matrix is 3 by 3 but each b matrix is 2 by 3